### PR TITLE
Update self-certification program link's subdomain (match link from OSHWA homepage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repository contains artwork and usage guidelines for the graphic mark of the [Open Source Hardware Self-Certification program](http://certificate.oshwa.org/) hosted by OSHWA. 
+This repository contains artwork and usage guidelines for the graphic mark of the [Open Source Hardware Self-Certification program](https://certification.oshwa.org/) hosted by OSHWA. 
 
 [This page](http://oshwmark.capablerobot.com/) will help you generate a version of the logo with your UID.
 


### PR DESCRIPTION
Small fix: It looks like there's a link in the README which refers to a previously-used subdomain of `certificate.oshwa.org` (at the time of writing, visiting that page results in a TLS bad-cert-domain validation error).